### PR TITLE
Modified imports in RegistrationForm.js to accept proper display of Button and Form components

### DIFF
--- a/src/components/RegistrationForm.js
+++ b/src/components/RegistrationForm.js
@@ -1,7 +1,6 @@
 import PropTypes from 'prop-types';
 import { useState } from 'react';
-import { Button } from 'react-bootstrap/Button';
-import { Form } from 'react-bootstrap/Form';
+import { Form, Button } from 'react-bootstrap';
 import { registerUser } from '../utils/auth';
 
 function RegisterForm({ user, updateUser }) {


### PR DESCRIPTION
## Description
This pull request corrected the React Bootstrap imports in the RegistrationForm component.

## Motivation and Context
This change was motivated by a TypeError message claiming that a specific property(_Group_ in `Form.Group`) was undefined. 

Now when a user is done being authenticated, the UI no longer appears with error messages.

## How Can This Be Tested?
1. Ensure Django Server is running in the background
   - Start the server with `python3 manage.py runserver` or `python manage.py runserver`
2. Start the application with `npm run dev`
3. Proceed by signing in with a new Google account
4. Verify that the registration form displays correctly and that no console errors or warnings appear
5. Fill out the bio field and submit the form
6. Confirm that the UI appears with your google-associated alias, bio, and options to sign out.

## Screenshots (if appropriate):
### TypeError message prior to fix
![image](https://github.com/user-attachments/assets/604e4a30-cd8c-4106-b753-9e8239287b8b)

### UI when a user is first authenticated but is not registered
![Screenshot 2025-05-29 at 2 25 40 PM](https://github.com/user-attachments/assets/f45abc3d-32c7-4578-b14d-005ad46d475e)

### UI when a user is authenticated and is registered
![Screenshot 2025-05-29 at 2 38 41 PM](https://github.com/user-attachments/assets/e516e284-a67f-46a0-b6a3-41e4cbd28d43)


## Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)